### PR TITLE
Download wkhtmltopdf URL changed

### DIFF
--- a/odoo-v8/ubuntu-14-04/odoo_install.sh
+++ b/odoo-v8/ubuntu-14-04/odoo_install.sh
@@ -61,7 +61,7 @@ echo -e "\n---- Install python libraries ----"
 sudo pip install gdata
 
 echo -e "\n---- Install wkhtml and place on correct place for ODOO 8 ----"
-sudo wget http://downloads.sourceforge.net/project/wkhtmltopdf/archive/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb
+sudo wget http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb
 sudo dpkg -i wkhtmltox-0.12.1_linux-trusty-amd64.deb
 sudo cp /usr/local/bin/wkhtmltopdf /usr/bin
 sudo cp /usr/local/bin/wkhtmltoimage /usr/bin


### PR DESCRIPTION
All downloads are now hosted at http://download.gna.org/wkhtmltopdf/ The
migration was announced on 2-July-2015, see the post on mailing list
https://groups.google.com/forum/#!msg/wkhtmltopdf-general/wZwTUol3mXI/GNVeyrKDdqIJ
You can subscribe to the mailing list or Twitter feed to receive updates
on new releases and further changes.